### PR TITLE
Fix caching issue when creating board

### DIFF
--- a/app/g/[gameSecret]/b/page.tsx
+++ b/app/g/[gameSecret]/b/page.tsx
@@ -17,8 +17,13 @@ export default async function Page({ params }: { params: { gameSecret: string } 
 		return <p>Error: no game</p>;
 	}
 
-	const userTasks = await getUserTasksWithInfo(games[0].id, user.id);
-	if (userTasks?.length) {
+	const { count } = await supabase
+		.from('users_tasks')
+		.select('*', { count: 'exact', head: true })
+		.eq('user_id', user.id);
+
+	if (count) {
+		const userTasks = await getUserTasksWithInfo(games[0].id, user.id);
 		return (
 			<ScreenLayout title={games[0].name}>
 				<Board tasks={userTasks} />


### PR DESCRIPTION
There was an issue (only on the deployment) when the initial game board was being created (for a user with no user tasks), the the query was not making it to the database. I changed it to get the count of the `user_tasks` where the `user_id` matched the current logged in user *first*. If there were none, then it creates the board, and then queries the `users_tasks` for the actual tasks with information. I _think_ this is due to caching and running the same query in such a short period of time.