### PR TITLE
Fix/bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+log.txt
 
 # local env files
 .env*.local

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,86 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+npm run dev      # Start dev server on localhost:3000
+npm run build    # Build for production
+npm run start    # Start production server
+```
+
+There is no test suite or lint script configured.
+
+## Environment Variables
+
+Copy `.env.example` to `.env.local` and fill in:
+- `SUPABASE_URL` / `SUPABASE_SERVICE_KEY` — Supabase project credentials
+- `GOOGLE_CLIENT_ID` / `GOOGLE_SECRET_ID` — Google OAuth app credentials
+- `NEXTAUTH_SECRET` — random secret for NextAuth session signing
+- `NEXTAUTH_URL` — base URL of the app (e.g. `http://localhost:3000`)
+
+## Architecture
+
+This is a Next.js 14 App Router project. Pages are server components by default; client components are explicitly marked `'use client'`.
+
+### Authentication flow
+
+NextAuth (v4) handles OAuth via Google. `utils/auth.ts` exports two things:
+- `authOptions` — the NextAuth config, used at `app/api/auth/[...nextauth]/route.ts`
+- `getUser()` (default export) — a server-side helper that calls `getServerSession`, then looks up or auto-creates the user in Supabase's `users` table by email. Any server page that requires auth calls this; it redirects to `/login?redirect_to=...` if there's no session.
+
+The root `app/page.tsx` is a **client component** that checks for a session via `useSession` and redirects to `/login` client-side. This is intentional — it avoids a server-side redirect on the landing page so the "game secret" input form can render.
+
+### Supabase client
+
+`utils/supabase/server.ts` creates a server-side Supabase client using `@supabase/ssr`. It uses the **service key** (bypasses RLS), so all access control is enforced in application logic (e.g. `updateCompletedStatusOfTask` validates `user_id` matches before writing).
+
+### Routing
+
+```
+/                          → game secret entry (client component)
+/login                     → OAuth login page
+/g/[gameSecret]            → game landing page (shows name/tagline)
+/g/[gameSecret]/b          → the bingo board
+/g/[gameSecret]/b/[id]     → single task detail / mark complete
+/g/[gameSecret]/print      → print preview with configurable copies
+```
+
+### Board generation
+
+When a user first visits `/g/[gameSecret]/b`, the page checks whether `users_tasks` rows already exist for that user. If not, it calls `createBoard` (`utils/createBoard.ts`), which:
+1. Pulls the task with `type === 'center'` and places it at grid position (2, 2)
+2. Shuffles all remaining tasks and fills the 5×5 grid, skipping (2, 2)
+3. Inserts 25 `users_tasks` rows into Supabase
+
+Board requires at least 24 non-center tasks in the game.
+
+### Free space tasks
+
+The center cell (type `center`) may have no preset description. Users can write their own via the `free_space_user_added_tasks` table. `getUserTasksWithInfo` joins this table and prefers the user-written description when present.
+
+### Database schema (key tables)
+
+- `games` — name, tagline, secret (join code), status, expiry
+- `tasks` — one row per task template; `type` is `'center'` or anything else
+- `users_tasks` — per-user board state; holds `grid_row`, `grid_column`, `completed`, `completed_at`
+- `free_space_user_added_tasks` — optional user-defined description for center cells
+- `users` — auto-created on first login from Google OAuth data
+
+Schema initialization SQL is in `db/init.sql`.
+
+### Styling
+
+Tailwind CSS with two custom colors (`gold: #84726A`, `lightGold: #CCC0B7`) and two custom breakpoints (`print` / `screen`) for print-vs-screen visibility toggling. Font is Averia Serif Libre (Google Fonts, weight 300) applied globally in `app/layout.tsx`.
+
+### Server Actions
+
+Mutation utilities use `'use server'` and call `revalidatePath` after writes to bust Next.js cache:
+- `updateCompletedStatusOfTask` — toggles `completed` + `completed_at` on a `users_tasks` row
+- `addFreeSpaceUserTask` — inserts into `free_space_user_added_tasks`
+- `checkForGame` — looks up a game by secret and redirects if found
+
+### Admin
+
+There is no in-app admin UI. Games and tasks are managed directly through the Supabase dashboard.

--- a/app/g/[gameSecret]/b/page.tsx
+++ b/app/g/[gameSecret]/b/page.tsx
@@ -19,8 +19,9 @@ export default async function Page({ params }: { params: { gameSecret: string } 
 
 	const { count } = await supabase
 		.from('users_tasks')
-		.select('*', { count: 'exact', head: true })
-		.eq('user_id', user.id);
+		.select('*, tasks!inner(game_id)', { count: 'exact', head: true })
+		.eq('user_id', user.id)
+		.eq('tasks.game_id', games[0].id);
 
 	if (count) {
 		const userTasks = await getUserTasksWithInfo(games[0].id, user.id);
@@ -46,10 +47,10 @@ export default async function Page({ params }: { params: { gameSecret: string } 
 			grid_column: task.grid_column,
 		})),
 	);
-	const newUserTasks = await getUserTasksWithInfo(games[0].id, user.id);
 	if (error) {
 		throw error;
 	}
+	const newUserTasks = await getUserTasksWithInfo(games[0].id, user.id);
 	return (
 		<ScreenLayout title={games[0].name}>
 			<Board tasks={newUserTasks} />

--- a/app/g/[gameSecret]/layout.tsx
+++ b/app/g/[gameSecret]/layout.tsx
@@ -1,0 +1,12 @@
+import getUser from '@/utils/auth';
+
+export default async function GameLayout({
+	children,
+	params,
+}: {
+	children: React.ReactNode;
+	params: { gameSecret: string };
+}) {
+	await getUser(`/g/${params.gameSecret}`);
+	return <>{children}</>;
+}

--- a/app/g/[gameSecret]/print/page.tsx
+++ b/app/g/[gameSecret]/print/page.tsx
@@ -1,11 +1,9 @@
 import { createClient } from '@/utils/supabase/server';
 
 import PrintConfiguration from '@/components/PrintConfiguration';
-import getUser from '@/utils/auth';
 
 export default async function page({ params }: { params: { gameSecret: string } }) {
   const supabase = createClient();
-  await getUser(`/g/${params.gameSecret}/print/`);
   const { data: games } = await supabase
     .from('games')
     .select()

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,78 +1,16 @@
-'use client';
-import checkForGame from '@/utils/checkForGame';
-import { signOut, useSession } from 'next-auth/react';
-import { useRouter } from 'next/navigation';
-import react, { useEffect, useState } from 'react';
-import toast, { Toaster } from 'react-hot-toast';
+import { authOptions } from '@/utils/auth';
+import HomeForm from '@/components/HomeForm';
+import { getServerSession } from 'next-auth';
+import { redirect } from 'next/navigation';
 
-export default function Home() {
-  const { data: session } = useSession();
-  const [gameSecret, setGameSecret] = useState<string>('');
-  const [gameNotFoundMessage, setMessage] = useState({ title: '', subtitle: '' });
-  const router = useRouter();
-  useEffect(() => {
-    const timerId = setTimeout(() => {
-      if (!session?.user) router.push('/login');
-    }, 1000);
-    return () => {
-      clearTimeout(timerId);
-    };
-  }, [session?.user]);
-  useEffect(() => {
-    const timerId = setTimeout(() => {
-      toast.success('Try password `coffee-secret-123`', { duration: 30_000 });
-    }, 500);
-    return () => {
-      clearTimeout(timerId);
-    };
-  }, []);
+export default async function Home() {
+	const session = await getServerSession(authOptions);
+	if (!session) redirect('/login');
 
-  const goToGame = async (e: react.FormEvent) => {
-    e.preventDefault();
-    const message = await checkForGame(gameSecret);
-    setMessage(message);
-  };
-
-  return (
-    <section className="text-gold mt-28 mx-10 flex flex-col items-center">
-      <h1 className="text-5xl text-center my-14"> WELCOME TO BINGO</h1>
-      {session?.user ? (
-        <>
-          <form className="flex flex-col items-center justify-center">
-            <label className="flex flex-col items-start text-xl">
-              Game Secret:
-              <input
-                required
-                className="text-l border rounded-sm border-lightGold p-3"
-                placeholder="Enter your game secret"
-                value={gameSecret}
-                onChange={(e) => setGameSecret(e.target.value)}
-              />
-            </label>
-            {gameNotFoundMessage?.title ? (
-              <p className="text-red-500 text-xl">
-                {gameNotFoundMessage.title}
-                <span className="block">{gameNotFoundMessage.subtitle}</span>
-              </p>
-            ) : null}
-            <button
-              onClick={(e) => goToGame(e)}
-              className="border bg-lightGold text-2xl py-2 px-14 mt-8 rounded-sm border-lightGold bg-opacity-40"
-            >
-              Go to Game
-            </button>
-          </form>
-          <button
-            className="border bg-lightGold text-xl py-2 px-8 mt-8 rounded-sm border-lightGold bg-opacity-20"
-            onClick={() => signOut()}
-          >
-            Sign out
-          </button>
-        </>
-      ) : (
-        'Loading...'
-      )}
-      <Toaster position="top-right" />
-    </section>
-  );
+	return (
+		<section className="text-gold mt-28 mx-10 flex flex-col items-center">
+			<h1 className="text-5xl text-center my-14">WELCOME TO BINGO</h1>
+			<HomeForm />
+		</section>
+	);
 }

--- a/components/AddTask.tsx
+++ b/components/AddTask.tsx
@@ -1,0 +1,44 @@
+'use client';
+import { useState } from 'react';
+
+export default function AddTask() {
+	const [description, setDescription] = useState('');
+	const [photoRequired, setPhotoRequired] = useState(false);
+
+	const addTask = (e: React.FormEvent) => {
+		e.preventDefault();
+		// TODO: insert task into DB
+	};
+
+	return (
+		<article className="text-gold m-8 flex border rounded-md border-gold">
+			<form onSubmit={addTask}>
+				<h2 className="text-2xl my-3 mx-8">Add Task</h2>
+				<label className="flex flex-col items-start text-xl m-8">
+					Description
+					<textarea
+						className="text-l border rounded-sm border-lightGold invalid:border-red-500 p-3 mt-3"
+						value={description}
+						onChange={(e) => setDescription(e.target.value)}
+					></textarea>
+				</label>
+				<label className="text-xl m-8">
+					{' '}
+					Photo required
+					<input
+						type="checkbox"
+						className="ml-3"
+						checked={photoRequired}
+						onChange={(e) => setPhotoRequired((prev) => !prev)}
+					/>
+				</label>
+				<div className="flex justify-end">
+					<button className="border bg-lightGold text-l py-2 px-8 m-3 mt-6 ml-8 rounded-sm border-lightGold bg-opacity-40">
+						Add
+					</button>
+				</div>
+				{/*on click => upsert game and add task to DB*/}
+			</form>
+		</article>
+	);
+}

--- a/components/HomeForm.tsx
+++ b/components/HomeForm.tsx
@@ -1,0 +1,59 @@
+'use client';
+import checkForGame from '@/utils/checkForGame';
+import { signOut } from 'next-auth/react';
+import { useEffect, useState } from 'react';
+import toast, { Toaster } from 'react-hot-toast';
+
+export default function HomeForm() {
+	const [gameSecret, setGameSecret] = useState('');
+	const [gameNotFoundMessage, setMessage] = useState({ title: '', subtitle: '' });
+
+	useEffect(() => {
+		const timerId = setTimeout(() => {
+			toast.success('Try password `coffee-secret-123`', { duration: 30_000 });
+		}, 500);
+		return () => clearTimeout(timerId);
+	}, []);
+
+	const goToGame = async (e: React.FormEvent) => {
+		e.preventDefault();
+		const message = await checkForGame(gameSecret);
+		setMessage(message);
+	};
+
+	return (
+		<>
+			<form className="flex flex-col items-center justify-center" onSubmit={goToGame}>
+				<label className="flex flex-col items-start text-xl">
+					Game Secret:
+					<input
+						required
+						className="text-l border rounded-sm border-lightGold p-3"
+						placeholder="Enter your game secret"
+						value={gameSecret}
+						onChange={(e) => setGameSecret(e.target.value)}
+					/>
+				</label>
+				{gameNotFoundMessage?.title ? (
+					<p className="text-red-500 text-xl">
+						{gameNotFoundMessage.title}
+						<span className="block">{gameNotFoundMessage.subtitle}</span>
+					</p>
+				) : null}
+				<button
+					type="submit"
+					className="border bg-lightGold text-2xl py-2 px-14 mt-8 rounded-sm border-lightGold bg-opacity-40"
+				>
+					Go to Game
+				</button>
+			</form>
+			<button
+				className="border bg-lightGold text-xl py-2 px-8 mt-8 rounded-sm border-lightGold bg-opacity-20"
+				onClick={() => signOut()}
+			>
+				Sign out
+			</button>
+			<Toaster position="top-right" />
+		</>
+	);
+}

--- a/components/Login.tsx
+++ b/components/Login.tsx
@@ -4,7 +4,8 @@ import { useSearchParams } from 'next/navigation';
 
 export default function Login() {
   const { data: session } = useSession();
-  const callbackUrl = useSearchParams().get('redirect_to');
+  const rawRedirect = useSearchParams().get('redirect_to');
+  const callbackUrl = rawRedirect?.startsWith('/') ? rawRedirect : '/';
   return (
     <section className="text-gold mt-28 mx-10 flex flex-col items-center">
       <h1 className="text-5xl text-center"> WELCOME TO BINGO</h1>
@@ -26,7 +27,7 @@ export default function Login() {
             className="border bg-lightGold text-2xl py-2 px-14 rounded-sm border-lightGold bg-opacity-20"
             onClick={() =>
               signIn('google', {
-                callbackUrl: callbackUrl ?? '',
+                callbackUrl,
               })
             }
           >

--- a/utils/auth.ts
+++ b/utils/auth.ts
@@ -1,3 +1,4 @@
+import { cache } from 'react';
 import { NextAuthOptions, getServerSession } from 'next-auth';
 import { redirect } from 'next/navigation';
 import { createClient } from './supabase/server';
@@ -14,21 +15,24 @@ export const authOptions: NextAuthOptions = {
 	secret: process.env.NEXTAUTH_SECRET as string,
 };
 
-export default async function getUser(redirectTo?: string): Promise<User> {
-	const session = await getServerSession(authOptions);
-	if (!session) return redirect(`/login?redirect_to=${encodeURIComponent(redirectTo ?? '')}`);
+const fetchUserByEmail = cache(async (email: string, name: string | null | undefined, image: string | null | undefined): Promise<User> => {
 	const supabase = createClient();
-
-	const { data: user, error: selectError } = await supabase.from('users').select().eq('email', session.user?.email);
+	const { data: user, error: selectError } = await supabase.from('users').select().eq('email', email);
 	if (selectError) throw selectError;
 	if (!user?.length) {
 		const { data: newUser, error: insertError } = await supabase
 			.from('users')
-			.insert({ name: session.user?.name, email: session.user?.email, profile_photo: session.user?.image })
+			.insert({ name, email, profile_photo: image })
 			.select();
 		if (insertError) throw insertError;
 		if (!newUser?.length) throw new Error('failed to create new user');
 		return newUser[0];
 	}
 	return user[0];
+});
+
+export default async function getUser(redirectTo?: string): Promise<User> {
+	const session = await getServerSession(authOptions);
+	if (!session) return redirect(`/login?redirect_to=${encodeURIComponent(redirectTo ?? '')}`);
+	return fetchUserByEmail(session.user!.email!, session.user?.name, session.user?.image);
 }

--- a/utils/auth.ts
+++ b/utils/auth.ts
@@ -19,15 +19,16 @@ export default async function getUser(redirectTo?: string): Promise<User> {
 	if (!session) return redirect(`/login?redirect_to=${encodeURIComponent(redirectTo ?? '')}`);
 	const supabase = createClient();
 
-	const { data: user } = await supabase.from('users').select().eq('email', session.user?.email);
+	const { data: user, error: selectError } = await supabase.from('users').select().eq('email', session.user?.email);
+	if (selectError) throw selectError;
 	if (!user?.length) {
-		const { data: newUser, error } = await supabase
+		const { data: newUser, error: insertError } = await supabase
 			.from('users')
 			.insert({ name: session.user?.name, email: session.user?.email, profile_photo: session.user?.image })
 			.select();
-		if (!newUser) throw new Error('failed to create new user');
+		if (insertError) throw insertError;
+		if (!newUser?.length) throw new Error('failed to create new user');
 		return newUser[0];
 	}
 	return user[0];
 }
-//if error tell user to retry?

--- a/utils/createBoard.ts
+++ b/utils/createBoard.ts
@@ -1,7 +1,7 @@
 import { Task, UserTask } from './types';
 
 export default function createBoard(tasks: Task[], userId: number): UserTask[] {
-	if (tasks.length < 24) {
+	if (tasks.length < 25) {
 		throw new Error('Not enough tasks for game');
 	}
 	const game_id = tasks[0].game_id;

--- a/utils/getUserTasks.ts
+++ b/utils/getUserTasks.ts
@@ -8,7 +8,7 @@ export default async function getUserTasksWithInfo(
   const supabase = createClient();
   const { data, error: fetchError } = await supabase
     .from('users_tasks')
-    .select(`*,tasks(game_id, type, description),free_space_user_added_tasks(description)`)
+    .select(`*,tasks!inner(game_id, type, description),free_space_user_added_tasks(description)`)
     .eq('tasks.game_id', gameId)
     .eq('user_id', userId);
   if (fetchError) {


### PR DESCRIPTION
  ## Summary
  - Fix `getUserTasks` crash for multi-game users — embedded relation filter returned `tasks: null`, causing a TypeError on
  `.game_id` access; switched to `!inner` join
  - Fix board page showing wrong/empty board for returning players — `users_tasks` count was not scoped to the current game
  - Fix auth error handling in `getUser` — select and insert errors were silently swallowed
  - Fix open redirect on login — `callbackUrl` now validated to same-origin paths only
  - Fix `createBoard` minimum task guard — was `< 24`, needs `< 25`
  - Fix `AddTask` form — missing `onSubmit` caused page reload on submit
  - Convert home page to server component — eliminates 1-second timeout that caused false redirects to `/login` on
  production
  - Centralize auth in game route layout — protects all `/g/[gameSecret]/*` routes
  
  ## Test plan
  - [ ] Returning player can open a new game and gets a fresh board
  - [ ] Going to `/` while logged in does not redirect to `/login`
  - [ ] Going to `/` while logged out redirects immediately
  - [ ] Login redirects back to the original page after sign-in
  - [ ] Marking a task complete/incomplete works
  - [ ] Print preview generates correct number of boards