### PR TITLE
Fix sign-out by reverting home page to client component; add Google a…

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,16 +1,78 @@
-import { authOptions } from '@/utils/auth';
-import HomeForm from '@/components/HomeForm';
-import { getServerSession } from 'next-auth';
-import { redirect } from 'next/navigation';
+'use client';
+import checkForGame from '@/utils/checkForGame';
+import { signOut, useSession } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
+import react, { useEffect, useState } from 'react';
+import toast, { Toaster } from 'react-hot-toast';
 
-export default async function Home() {
-	const session = await getServerSession(authOptions);
-	if (!session) redirect('/login');
+export default function Home() {
+  const { data: session } = useSession();
+  const [gameSecret, setGameSecret] = useState<string>('');
+  const [gameNotFoundMessage, setMessage] = useState({ title: '', subtitle: '' });
+  const router = useRouter();
+  useEffect(() => {
+    const timerId = setTimeout(() => {
+      if (!session?.user) router.push('/login');
+    }, 1000);
+    return () => {
+      clearTimeout(timerId);
+    };
+  }, [session?.user]);
+  useEffect(() => {
+    const timerId = setTimeout(() => {
+      toast.success('Try password `coffee-secret-123`', { duration: 30_000 });
+    }, 500);
+    return () => {
+      clearTimeout(timerId);
+    };
+  }, []);
 
-	return (
-		<section className="text-gold mt-28 mx-10 flex flex-col items-center">
-			<h1 className="text-5xl text-center my-14">WELCOME TO BINGO</h1>
-			<HomeForm />
-		</section>
-	);
+  const goToGame = async (e: react.FormEvent) => {
+    e.preventDefault();
+    const message = await checkForGame(gameSecret);
+    setMessage(message);
+  };
+
+  return (
+    <section className="text-gold mt-28 mx-10 flex flex-col items-center">
+      <h1 className="text-5xl text-center my-14"> WELCOME TO BINGO</h1>
+      {session?.user ? (
+        <>
+          <form className="flex flex-col items-center justify-center">
+            <label className="flex flex-col items-start text-xl">
+              Game Secret:
+              <input
+                required
+                className="text-l border rounded-sm border-lightGold p-3"
+                placeholder="Enter your game secret"
+                value={gameSecret}
+                onChange={(e) => setGameSecret(e.target.value)}
+              />
+            </label>
+            {gameNotFoundMessage?.title ? (
+              <p className="text-red-500 text-xl">
+                {gameNotFoundMessage.title}
+                <span className="block">{gameNotFoundMessage.subtitle}</span>
+              </p>
+            ) : null}
+            <button
+              onClick={(e) => goToGame(e)}
+              className="border bg-lightGold text-2xl py-2 px-14 mt-8 rounded-sm border-lightGold bg-opacity-40"
+            >
+              Go to Game
+            </button>
+          </form>
+          <button
+            className="border bg-lightGold text-xl py-2 px-8 mt-8 rounded-sm border-lightGold bg-opacity-20"
+            onClick={() => signOut()}
+          >
+            Sign out
+          </button>
+        </>
+      ) : (
+        'Loading...'
+      )}
+      <Toaster position="top-right" />
+    </section>
+  );
 }

--- a/components/BoardRow.tsx
+++ b/components/BoardRow.tsx
@@ -52,7 +52,7 @@ function TaskContents({ task }: { task: EnrichedUserTask }) {
 			{task.type !== 'center' ? (
 				<span className="text-ellipsis overflow-hidden hyphens-auto">{task.description}</span>
 			) : (
-				<Image src={centerPhoto} alt="a + e, andrew and erika" />
+				<Image src={centerPhoto} alt="center of bingo board, looks like coffee beans" />
 			)}
 		</>
 	);

--- a/utils/auth.ts
+++ b/utils/auth.ts
@@ -10,6 +10,7 @@ export const authOptions: NextAuthOptions = {
 		GoogleProvider({
 			clientId: process.env.GOOGLE_CLIENT_ID as string,
 			clientSecret: process.env.GOOGLE_SECRET_ID as string,
+			authorization: { params: { prompt: 'select_account' } },
 		}),
 	],
 	secret: process.env.NEXTAUTH_SECRET as string,

--- a/utils/createBoard.ts
+++ b/utils/createBoard.ts
@@ -45,7 +45,7 @@ export default function createBoard(tasks: Task[], userId: number): UserTask[] {
 	}
 	return userTasks;
 }
-
+//Fisher-Yates shuffle
 function shuffle(a: Task[]) {
 	const b = [...a];
 	var j, x, i;


### PR DESCRIPTION
This rolls back a breaking change

The home page was converted to a server component in a previous PR, removing the useEffect session watcher that redirected to /login after sign-out. This caused a client/server hydration mismatch that broke the game code form. Reverted app/page.tsx to a client component to restore that behavior.

Added prompt: 'select_account' to the Google provider so sign-in always shows the account picker rather than silently re-authenticating.